### PR TITLE
Handle database errors in account endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Added basic account endpoints and health check.
 - Created initial requirements file.
 - Included placeholder `data/` directory for local SQLite storage.
+- Wrapped account endpoints with SQLAlchemy error handling and logging for clearer troubleshooting.

--- a/app/main.py
+++ b/app/main.py
@@ -2,9 +2,14 @@
 
 from fastapi import FastAPI, HTTPException
 from sqlmodel import select
+from sqlalchemy.exc import SQLAlchemyError
+import logging
 
 from .database import init_db, get_session
 from .models import Account
+
+# Configure a module-level logger for consistent debugging messages.
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Personal Account Manager")
 
@@ -25,19 +30,33 @@ def read_root() -> dict[str, str]:
 def list_accounts() -> list[Account]:
     """Return all accounts in the system."""
     with get_session() as session:
-        accounts = session.exec(select(Account)).all()
-        return accounts
+        try:
+            return session.exec(select(Account)).all()
+        except SQLAlchemyError as exc:
+            session.rollback()  # Ensure the session is clean for subsequent operations.
+            logger.exception("Database error while listing accounts")
+            raise HTTPException(
+                status_code=500,
+                detail="Database error while listing accounts",
+            ) from exc
 
 
 @app.post("/accounts", response_model=Account)
 def create_account(account: Account) -> Account:
-    """Create a new account with basic error handling."""
+    """Create a new account with database error handling.
+
+    Errors are logged and surfaced to aid junior admins in troubleshooting.
+    """
     with get_session() as session:
         try:
             session.add(account)
             session.commit()
             session.refresh(account)
             return account
-        except Exception as exc:  # Catch generic issues for clarity
-            # Raising an HTTPException ensures the API responds cleanly.
-            raise HTTPException(status_code=400, detail=str(exc))
+        except SQLAlchemyError as exc:
+            session.rollback()  # Prevent partial commits on failure.
+            logger.exception("Database error while creating an account")
+            raise HTTPException(
+                status_code=500,
+                detail="Database error while creating account",
+            ) from exc


### PR DESCRIPTION
## Summary
- log database exceptions with `logging` and surface 500 errors for account endpoints
- document database error handling in changelog

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ad8b88a4c8329b26c59147866bd0c