### PR TITLE
Add dashboard page and navigation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Added dashboard interface and navigation links for easier page access.
 - Added cloning instructions to README for new developers.
 - Updated cloning example to use the curlyphries GitHub account.
 - Added logging to database initialization and session helpers for clearer troubleshooting.

--- a/app/main.py
+++ b/app/main.py
@@ -38,6 +38,16 @@ def render_ui(request: Request) -> HTMLResponse:
     return templates.TemplateResponse("index.html", {"request": request})
 
 
+@app.get("/dashboard", response_class=HTMLResponse, summary="Application dashboard")
+def render_dashboard(request: Request) -> HTMLResponse:
+    """Render the dashboard page with basic error handling for transparency."""
+    try:
+        return templates.TemplateResponse("dashboard.html", {"request": request})
+    except Exception as exc:  # Broad except to log unexpected template errors
+        logger.exception("Error rendering dashboard")
+        raise HTTPException(status_code=500, detail="Error loading dashboard") from exc
+
+
 @app.get("/accounts", response_model=list[Account])
 def list_accounts() -> list[Account]:
     """Return all accounts in the system."""

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Dashboard</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    nav a { margin-right: 1rem; }
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="/ui">Accounts</a>
+    <a href="/dashboard">Dashboard</a>
+  </nav>
+  <h1>Dashboard</h1>
+  <p>Welcome to your dashboard. Use the navigation links to explore the app.</p>
+</body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,6 +5,7 @@
   <title>Personal Account Manager</title>
   <style>
     body { font-family: Arial, sans-serif; margin: 2rem; }
+    nav a { margin-right: 1rem; }
     table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
     th, td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }
     th { background-color: #f0f0f0; }
@@ -12,6 +13,10 @@
   </style>
 </head>
 <body>
+  <nav>
+    <a href="/ui">Accounts</a>
+    <a href="/dashboard">Dashboard</a>
+  </nav>
   <h1>Accounts</h1>
   <div id="error"></div>
   <form id="create-form">

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,26 @@
+import os
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel
+
+# Use an in-memory SQLite database for isolated tests
+os.environ["DATABASE_URL"] = "sqlite://"
+
+from app.main import app  # noqa: E402  # Import after setting DATABASE_URL
+from app.database import engine
+
+
+@pytest.fixture(name="client")
+def client_fixture():
+    """Provide a TestClient for UI routes with a fresh database."""
+    SQLModel.metadata.drop_all(engine)
+    SQLModel.metadata.create_all(engine)
+    with TestClient(app) as client:
+        yield client
+
+
+def test_dashboard_route(client):
+    """Dashboard page should render successfully."""
+    response = client.get("/dashboard")
+    assert response.status_code == 200
+    assert "Dashboard" in response.text


### PR DESCRIPTION
## Summary
- serve a new dashboard page with navigation links
- expose `/dashboard` route with error handling
- link existing UI to the dashboard

## Testing
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_689af476a48c83298e94adbbf07a3ca2